### PR TITLE
chore: change clearInterval to clearTimeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ export default class HIBPPasswordChecker extends Component {
       })
     } else if (nextProps.password !== this.props.password) {
       if (this.interval) {
-        clearInterval(this.interval)
+        clearTimeout(this.interval)
       }
       this.interval = setTimeout(() => {
         this.checkPassword(nextProps.password)


### PR DESCRIPTION
Hey hey!

Was just having a look at the code and saw it used `clearInterval` for a timeout. 
[MDN](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout) recommends matching clearTimeout -> setTimeout and clearInterval with setInterval - even though they share the same pool of IDs.